### PR TITLE
Make the env repo an optional property

### DIFF
--- a/jobs/shell/spec
+++ b/jobs/shell/spec
@@ -21,7 +21,6 @@ properties:
 
   shell.env.repo:
     description: "URL of a publicly-accessible shell environment repo"
-    default: "https://github.com/filefrog/env.git"
 
   shell.hosts:
     description: "A list of entries to append to /etc/hosts"

--- a/jobs/shell/templates/bin/setup
+++ b/jobs/shell/templates/bin/setup
@@ -27,7 +27,6 @@ fi
 NEW_USER="<%= p('shell.user.account') %>"
 NEW_HOME="/home/${NEW_USER}"
 NEW_SHELL="<%= p('shell.user.shell') %>"
-ENV_REPO="<%= p('shell.env.repo') %>"
 
 log "Setting up user ${NEW_USER}"
 if ! grep -q "^${NEW_USER}:" /etc/passwd; then
@@ -52,6 +51,10 @@ if ! grep -q '^<%= key %>$' ${NEW_HOME}/.ssh/authorized_keys; then
 fi
 <% end %>
 chown -R ${NEW_USER} ${NEW_HOME}
+
+<% if_p("shell.env.repo") do |env_repo| %>
+
+ENV_REPO="<%= env_repo %>"
 
 log "Setting up ${NEW_USER} environment"
 if [[ ! -d ${NEW_HOME}/env ]]; then
@@ -81,6 +84,8 @@ if [[ ! -d ${NEW_HOME}/env ]]; then
    export USER=${NEW_USER}
    [ -x ./install ] && ./install || true)
 fi
+
+<% end %>
 
 chown -R ${NEW_USER} ${NEW_HOME}
 touch /var/vcap/sys/run/shell


### PR DESCRIPTION
Git cannot always be installed, e.g.

``` sh
The following packages have unmet dependencies:
 git : Depends: libcurl3-gnutls (>= 7.16.2) but it is not going to be installed
       Depends: liberror-perl but it is not going to be installed
       Depends: git-man (> 1:1.9.1) but it is not going to be installed
       Depends: git-man (< 1:1.9.1-.) but it is not going to be installed
 nfs-common : Recommends: python but it is not going to be installed
              Breaks: nfs-kernel-server (< 1:1.2.8-6~) but 1:1.2.0-4ubuntu4.1 is to be installed
 nfs-kernel-server : Depends: librpcsecgss3 but it is not going to be installed
```

As far as bosh releases are concerned, packages must never be installed through the package manager. Always compile from source otherwise @cppforlife will give you the Russian eye.
